### PR TITLE
fixes tests

### DIFF
--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -51,7 +51,7 @@ class PaperdragonFileTest < MiniTest::Spec
         job.thumb!("16x16")
       end
 
-      assert file.data.size <= 457 # smaller after thumb!
+      assert file.data.size <= logo.size # smaller after thumb!
     end
 
     # additional metadata
@@ -106,7 +106,7 @@ class PaperdragonFileTest < MiniTest::Spec
 
       end
 
-      assert file.data.size <= 457
+      assert file.data.size <= original.data.size
     end
   end
 

--- a/test/paperclip_uid_test.rb
+++ b/test/paperclip_uid_test.rb
@@ -6,7 +6,7 @@ class PaperclipUidTest < MiniTest::Spec
   Uid = Paperdragon::Paperclip::Uid
 
   let (:options) { {:class_name => :avatars, :attachment => :image, :id => 1234,
-    :style => :original, :updated_at => Time.parse("20-06-2014 9:40:59").to_i,
+    :style => :original, :updated_at => Time.parse("20-06-2014 9:40:59 +1000").to_i,
     :file_name => "kristylee.jpg", :hash_secret => "secret"} }
 
   it { Uid.from(options).


### PR DESCRIPTION
this fixes two failed tests:
- On my machine file size after converting the logo to a 16x16 thumb is 476. This is smaller than the original size but not as much as the expected 457. Still the generated thumb are valid and constrained in "16x16". So I guess that the test can expect to have something smaller than the original size rather than 457
- Time parsing when timezone is not specified results in ruby taking the computer timezone.
tell me if it's ok!
cheers