### PR TITLE
Update file uid when storing if Dragonfly disambiguates it

### DIFF
--- a/lib/paperdragon/file/operations.rb
+++ b/lib/paperdragon/file/operations.rb
@@ -17,7 +17,13 @@ module Paperdragon
       # Upload file, delete old file if there is one.
       def upload!(job, old_uid, new_uid, metadata)
         puts "........................STORE  (process): #{uid}"
-        job.store(path: uid, :headers => {'x-amz-acl' => 'public-read', "Content-Type" => "image/jpeg"})
+        df_uid = job.store(path: uid, :headers => {'x-amz-acl' => 'public-read', "Content-Type" => "image/jpeg"})
+
+        # Dragonfly's filename disambiguation may change the uid
+        if df_uid != uid
+          uid = df_uid
+          metadata[:uid] = uid
+        end
 
         if new_uid # new uid means delete old one.
           puts "........................DELETE (reprocess): #{old_uid}"
@@ -73,3 +79,4 @@ module Paperdragon
     end
   end
 end
+


### PR DESCRIPTION
When trying to store a file and one exists wth the same name, Dragonfly will disambiguate it by altering the filename. When this happens, the `uid` changes and Paperdragon should follow suit.

For Paperdragon issue 8.