### PR TITLE
Use job mime type instead of image/jpeg

### DIFF
--- a/lib/paperdragon/file/operations.rb
+++ b/lib/paperdragon/file/operations.rb
@@ -17,7 +17,7 @@ module Paperdragon
       # Upload file, delete old file if there is one.
       def upload!(job, old_uid, new_uid, metadata)
         puts "........................STORE  (process): #{uid}"
-        job.store(path: uid, :headers => {'x-amz-acl' => 'public-read', "Content-Type" => "image/jpeg"})
+        job.store(path: uid, :headers => {'x-amz-acl' => 'public-read', "Content-Type" => job.mime_type})
 
         if new_uid # new uid means delete old one.
           puts "........................DELETE (reprocess): #{old_uid}"


### PR DESCRIPTION
I came across an issue where paperdragon was storing my SVGs with `Content-Type: image/jpeg` which meant that the images were not being rendered properly in the browser.

Instead, paperdragon should use Dragonfly's `job.mime_type`.

I see that there was an [old PR here](https://github.com/apotonick/paperdragon/pull/14/files) that was trying to make the same change. Not sure why it was closed though.